### PR TITLE
Refactor fragile HTML tests and document anti-patterns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,60 @@ $next = function () {
 - **Use PHPUnit attributes** for setup/teardown: `#[Before]` and `#[After]` instead of `setUp()` and `tearDown()` methods
 - When using `#[Before]`/`#[After]`, methods must be `protected` or `public`
 
+### Fragile HTML Test Patterns (Anti-Patterns to Avoid)
+
+When testing controllers that return HTML responses, avoid these fragile patterns:
+
+#### Anti-pattern #1: `assertSame()` with full HTML heredoc
+```php
+// ❌ FRÁGIL — qualquer mudança de indentação ou classe quebra o teste
+$expectedBody = <<<HTML
+<div class="wraper" role="table">
+    <div class="row" role="row">
+        ...
+    </div>
+</div>
+HTML;
+$this->assertSame($expectedBody, (string) $response->getBody());
+```
+
+**✅ Correto:** Usar `assertStringContainsString()` para partes específicas e `substr_count()` para contagens:
+```php
+$body = (string) $response->getBody();
+
+$this->assertStringContainsString('<div class="wraper" role="table"', $body);
+$this->assertStringContainsString('Datetime', $body);
+$this->assertStringContainsString('aria-label="Expand"', $body);
+
+$this->assertSame(1, substr_count($body, 'row-main'));
+$this->assertGreaterThanOrEqual(4, substr_count($body, 'field-toggle-btn'));
+```
+
+#### Anti-pattern #2: Hardcoded strings para acessibilidade
+```php
+// ❌ FRÁGIL — novos botões exigem atualização manual do teste
+$hasAccessibleLabel = str_contains($srOnlyText, 'Toggle') || str_contains($srOnlyText, 'Remove');
+```
+
+**✅ Correto:** Usar `DOMXPath` para verificar genericamente se TODO botão com ícone tem `aria-label` ou `sr-only`:
+```php
+$xpath = new \DOMXPath($dom);
+$buttons = $xpath->query('//button[.//span[contains(@class, "i-")]]');
+
+foreach ($buttons as $button) {
+    $ariaLabel = $button->getAttribute('aria-label');
+    $srSpans = $button->getElementsByTagName('span');
+    $hasSrText = false;
+    foreach ($srSpans as $span) {
+        if (str_contains($span->getAttribute('class'), 'sr-only')) {
+            $hasSrText = true;
+            break;
+        }
+    }
+    $this->assertTrue(! empty($ariaLabel) || $hasSrText, 'Icon button should have aria-label or sr-only text');
+}
+```
+
 ### Common Pitfalls
 - **Trailing whitespace**: When adding new test methods or code blocks, ensure no spaces at end of lines. PHPCS will fail with "Whitespace found at end of line" error.
 - **Mutation testing**: Use `CI=true make infection` or `composer test-infection` to run Infection. Tests added for mutation testing should explicitly verify the behavior being mutated (e.g., boundary conditions, default parameter values).

--- a/test/src/Accessibility/AccessibilityTest.php
+++ b/test/src/Accessibility/AccessibilityTest.php
@@ -299,13 +299,18 @@ class AccessibilityTest extends TestCase
         /** @var \DOMElement $button */
         foreach ($buttons as $button) {
             $ariaLabel = $button->getAttribute('aria-label');
-            $srOnlyText = $button->textContent;
-
-            $hasAccessibleLabel = ! empty($ariaLabel) || str_contains($srOnlyText, 'Toggle') || str_contains($srOnlyText, 'Remove');
+            $srSpans = $button->getElementsByTagName('span');
+            $hasSrText = false;
+            foreach ($srSpans as $span) {
+                if (str_contains($span->getAttribute('class'), 'sr-only')) {
+                    $hasSrText = true;
+                    break;
+                }
+            }
 
             $this->assertTrue(
-                $hasAccessibleLabel,
-                'Icon button should have aria-label or screen reader text'
+                ! empty($ariaLabel) || $hasSrText,
+                'Icon button should have aria-label or sr-only text'
             );
         }
     }

--- a/test/src/Controller/SearchActionTest.php
+++ b/test/src/Controller/SearchActionTest.php
@@ -17,110 +17,6 @@ class SearchActionTest extends TestCase
     /** @throws Exception */
     public function test_invoke_with_search_filter_returns_valid_response(): void
     {
-        $expectedBody = <<<HTML
-        <div class="wraper" role="table" aria-label="Log entries showing datetime, channel, level, and message">
-            <div class="sr-only" aria-live="polite" aria-atomic="true">
-                Showing 1 log entries
-            </div>
-            <div class="row fixed-header" role="row">
-                <div class="cell cell-header" role="columnheader" scope="col">&nbsp</div>
-                <div class="cell cell-header" role="columnheader" scope="col"><b>Datetime</b></div>
-                <div class="cell cell-header" role="columnheader" scope="col"><b>Channel</b></div>
-                <div class="cell cell-header" role="columnheader" scope="col"><b>Level</b><span class="sr-only"> (Log severity level)</span></div>
-                <div class="cell cell-header" role="columnheader" scope="col"><b>Message</b></div>
-                    </div>
-
-                            <div class="row row-main" role="row" tabindex="0" aria-label="Log entry: ERROR from a at 2025-04-28T10:00:00Z">
-                    <div class="cell" role="cell">
-                        <button
-                            aria-label="Expand"
-                            aria-expanded="false"
-                            aria-controls="log-content-0"
-                            onclick="toggleLogEntry(this)"
-                        >
-                            <span class="i i-caret"></span>
-                            <span class="sr-only">Expand</span>
-                        </button>
-                    </div>
-                    <div class="cell datetime" role="cell"><span>2025-04-28T10:00:00Z</span></div>
-                    <div class="cell channel" role="cell"><span>[a]</span></div>
-                    <div class="cell level error" role="cell">
-                        <span class="i i-error" aria-hidden="true"></span>
-                        <span>ERROR</span>
-                        <span class="sr-only">Level: ERROR</span>
-                    </div>
-                    <div class="cell message" role="cell"><span>m1</span></div>
-                            </div>
-                <div id="log-content-0" class="row details log-content collapsed" role="row">
-                    <div class="cell" role="cell" colspan="5">
-                        <ul class="nested-list">
-                    <li>
-                    <span class="highlight-key">
-                        <button
-                            class="field-toggle-btn"
-                            data-field="datetime"
-                            onclick="toggleField(event, 'datetime')"
-                            aria-label="Toggle column"
-                            title="Toggle column in table"
-                        >
-                            <span class="i i-table"></span>
-                            <span class="sr-only">Toggle column</span>
-                        </button>
-                        datetime            </span>
-                    <span class="highlight-string">2025-04-28T10:00:00Z</span>
-                </li>
-                    <li>
-                    <span class="highlight-key">
-                        <button
-                            class="field-toggle-btn"
-                            data-field="channel"
-                            onclick="toggleField(event, 'channel')"
-                            aria-label="Toggle column"
-                            title="Toggle column in table"
-                        >
-                            <span class="i i-table"></span>
-                            <span class="sr-only">Toggle column</span>
-                        </button>
-                        channel            </span>
-                    <span class="highlight-string">a</span>
-                </li>
-                    <li>
-                    <span class="highlight-key">
-                        <button
-                            class="field-toggle-btn"
-                            data-field="level"
-                            onclick="toggleField(event, 'level')"
-                            aria-label="Toggle column"
-                            title="Toggle column in table"
-                        >
-                            <span class="i i-table"></span>
-                            <span class="sr-only">Toggle column</span>
-                        </button>
-                        level            </span>
-                    <span class="highlight-string">ERROR</span>
-                </li>
-                    <li>
-                    <span class="highlight-key">
-                        <button
-                            class="field-toggle-btn"
-                            data-field="message"
-                            onclick="toggleField(event, 'message')"
-                            aria-label="Toggle column"
-                            title="Toggle column in table"
-                        >
-                            <span class="i i-table"></span>
-                            <span class="sr-only">Toggle column</span>
-                        </button>
-                        message            </span>
-                    <span class="highlight-string">m1</span>
-                </li>
-            </ul>
-                    </div>
-                </div>
-            </div>
-
-        HTML;
-
         $testFilter = 'error';
         $request = $this->createMock(ServerRequestInterface::class);
         $request
@@ -141,7 +37,37 @@ class SearchActionTest extends TestCase
 
         $this->assertSame(200, $response->getStatusCode());
         $this->assertSame(['text/html; charset=utf-8'], $response->getHeader('Content-Type'));
-        $this->assertSame($expectedBody, (string) $response->getBody());
+
+        $body = (string) $response->getBody();
+
+        $this->assertStringContainsString('<div class="wraper" role="table"', $body);
+        $this->assertStringContainsString('Showing 1 log entries', $body);
+        $this->assertStringContainsString('aria-live="polite"', $body);
+        $this->assertStringContainsString('aria-atomic="true"', $body);
+
+        $this->assertStringContainsString('Datetime', $body);
+        $this->assertStringContainsString('Channel', $body);
+        $this->assertStringContainsString('Level', $body);
+        $this->assertStringContainsString('Message', $body);
+
+        $this->assertStringContainsString('2025-04-28T10:00:00Z', $body);
+        $this->assertStringContainsString('[a]', $body);
+        $this->assertStringContainsString('ERROR', $body);
+        $this->assertStringContainsString('m1', $body);
+
+        $this->assertStringContainsString('field-toggle-btn', $body);
+        $this->assertStringContainsString('aria-label="Toggle column"', $body);
+
+        $this->assertStringContainsString('aria-label="Expand"', $body);
+        $this->assertStringContainsString('aria-expanded="false"', $body);
+
+        $this->assertStringContainsString('i-table', $body);
+        $this->assertStringContainsString('i-error', $body);
+        $this->assertStringContainsString('i-caret', $body);
+
+        $this->assertSame(1, substr_count($body, 'row-main'));
+        $this->assertGreaterThanOrEqual(4, substr_count($body, 'field-toggle-btn'));
+        $this->assertSame(4, substr_count($body, 'i-table'));
     }
 
     /** @throws Exception */

--- a/test/src/Middleware/ErrorHandlerMiddlewareTest.php
+++ b/test/src/Middleware/ErrorHandlerMiddlewareTest.php
@@ -24,10 +24,6 @@ final class ErrorHandlerMiddlewareTest extends TestCase
     private ServerRequestInterface&MockObject $request;
     private UriInterface&MockObject $uri;
 
-    private const string EXPECTED_HTML_ERROR = <<<'HTML'
-    <h1>An error occurred</h1>
-    HTML;
-
     #[Before]
     protected function init(): void
     {
@@ -292,6 +288,8 @@ final class ErrorHandlerMiddlewareTest extends TestCase
         $response = ($this->middleware)($this->request, $next);
 
         $this->assertSame(500, $response->getStatusCode());
-        $this->assertSame(self::EXPECTED_HTML_ERROR, (string) $response->getBody());
+        $body = (string) $response->getBody();
+        $this->assertStringContainsString('An error occurred', $body);
+        $this->assertStringContainsString('text/html', $response->getHeaderLine('Content-Type'));
     }
 }


### PR DESCRIPTION
- Replace assertSame() with full HTML heredoc by granular assertions (assertStringContainsString + substr_count) in SearchActionTest
- Replace fragile hardcoded accessibility strings with generic DOMXPath check in AccessibilityTest
- Remove fragile EXPECTED_HTML_ERROR constant and replace with flexible assertions in ErrorHandlerMiddlewareTest
- Document both anti-patterns and correct patterns in AGENTS.md under new 'Fragile HTML Test Patterns (Anti-Patterns to Avoid)' section

Closes: brittle HTML test patterns that break on indentation/class changes