### PR TITLE
Implement column reordering for additional fields

### DIFF
--- a/public/assets/icons/icons.css
+++ b/public/assets/icons/icons.css
@@ -89,6 +89,12 @@
 /* ARROW UP - Back to Top */
 .i-arrow-up { --i-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cline x1='12' y1='19' x2='12' y2='5'/%3E%3Cpolyline points='5 12 12 5 19 12'/%3E%3C/svg%3E"); }
 
+/* ARROW LEFT - Move column left (format: <-) */
+.i-chevron-left { --i-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cline x1='19' y1='12' x2='7' y2='12'/%3E%3Cpolyline points='13 17 7 12 13 7'/%3E%3C/svg%3E"); }
+
+/* ARROW RIGHT - Move column right (format: ->) */
+.i-chevron-right { --i-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cline x1='5' y1='12' x2='17' y2='12'/%3E%3Cpolyline points='11 17 17 12 11 7'/%3E%3C/svg%3E"); }
+
 .sr-only {
     position: absolute;
     width: 1px;

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -89,6 +89,26 @@ function createSelectedFieldsInput() {
   });
 }
 
+function moveFieldLeft(event, fieldName) {
+    event.stopPropagation();
+    const index = selectedFields.indexOf(fieldName);
+    if (index > 0) {
+        [selectedFields[index - 1], selectedFields[index]] = [selectedFields[index], selectedFields[index - 1]];
+        saveSelectedFields();
+        triggerSearch();
+    }
+}
+
+function moveFieldRight(event, fieldName) {
+    event.stopPropagation();
+    const index = selectedFields.indexOf(fieldName);
+    if (index < selectedFields.length - 1) {
+        [selectedFields[index], selectedFields[index + 1]] = [selectedFields[index + 1], selectedFields[index]];
+        saveSelectedFields();
+        triggerSearch();
+    }
+}
+
 function toggleField(event, fieldName) {
     event.stopPropagation();
     const isCurrentlySelected = isFieldSelected(fieldName);
@@ -279,6 +299,8 @@ window.toggleHighlight = toggleHighlight;
 window.toggleLogEntry = toggleLogEntry;
 window.triggerSearch = triggerSearch;
 window.clearLogs = clearLogs;
+window.moveFieldLeft = moveFieldLeft;
+window.moveFieldRight = moveFieldRight;
 
 // ==========================================================================
 // FOCUS MANAGEMENT & ACCESSIBILITY

--- a/public/styles.css
+++ b/public/styles.css
@@ -582,7 +582,21 @@ body.htmx-request #progress-bar {
 }
 
 .field-toggle-btn {
-    font-size: 0.6rem;
+    font-size: 0.875rem;
+}
+
+.field-actions {
+    display: inline-flex;
+    align-items: center;
+    gap: 2px;
+    margin-left: 4px;
+    vertical-align: middle;
+}
+
+.field-move-left,
+.field-move-right {
+    font-size: 0.875rem;
+    padding: 0 2px;
 }
 
 /* GRID PRINCIPAL */

--- a/templates/search/log-entry.phtml
+++ b/templates/search/log-entry.phtml
@@ -15,20 +15,49 @@
         <div class="cell cell-header" role="columnheader" scope="col"><b>Channel</b></div>
         <div class="cell cell-header" role="columnheader" scope="col"><b>Level</b><span class="sr-only"> (Log severity level)</span></div>
         <div class="cell cell-header" role="columnheader" scope="col"><b>Message</b></div>
+        <?php $fieldCount = count($this->fields); ?>
+        <?php $fieldIndex = 0; ?>
         <?php foreach ($this->fields as $field) : ?>
             <div class="cell cell-header" role="columnheader" scope="col">
                 <b><?= $this->renderAdidionalKey($field) ?></b>
-                <button
-                    class="field-toggle-btn"
-                    data-field="<?= $this->renderAdidionalKey($field) ?>"
-                    onclick="toggleField(event, '<?= $field ?>')"
-                    aria-label="Remove column"
-                    title="Remove column"
-                >
-                    <span class="i i-close"></span>
-                    <span class="sr-only">Remove column</span>
-                </button>
+                <span class="field-actions">
+                    <button
+                        class="field-toggle-btn"
+                        data-field="<?= $this->renderAdidionalKey($field) ?>"
+                        onclick="toggleField(event, '<?= $field ?>')"
+                        aria-label="Remove column"
+                        title="Remove column"
+                    >
+                        <span class="i i-close"></span>
+                        <span class="sr-only">Remove column</span>
+                    </button>
+                    <?php if ($fieldCount > 1 && $fieldIndex > 0) : ?>
+                        <button
+                            class="field-toggle-btn field-move-left"
+                            data-field="<?= $this->renderAdidionalKey($field) ?>"
+                            onclick="moveFieldLeft(event, '<?= $field ?>')"
+                            aria-label="Move column left"
+                            title="Move column left"
+                        >
+                            <span class="i i-chevron-left"></span>
+                            <span class="sr-only">Move column left</span>
+                        </button>
+                    <?php endif; ?>
+                    <?php if ($fieldCount > 1 && $fieldIndex < $fieldCount - 1) : ?>
+                        <button
+                            class="field-toggle-btn field-move-right"
+                            data-field="<?= $this->renderAdidionalKey($field) ?>"
+                            onclick="moveFieldRight(event, '<?= $field ?>')"
+                            aria-label="Move column right"
+                            title="Move column right"
+                        >
+                            <span class="i i-chevron-right"></span>
+                            <span class="sr-only">Move column right</span>
+                        </button>
+                    <?php endif; ?>
+                </span>
             </div>
+            <?php $fieldIndex++; ?>
         <?php endforeach; ?>
     </div>
 

--- a/test/src/Controller/SearchActionTest.php
+++ b/test/src/Controller/SearchActionTest.php
@@ -97,6 +97,91 @@ class SearchActionTest extends TestCase
     }
 
     /** @throws Exception */
+    public function test_invoke_with_fields_param_shows_move_buttons(): void
+    {
+        $testFields = ['datetime', 'message', 'custom'];
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request
+            ->expects($this->once())
+            ->method('getQueryParams')
+            ->willReturn(['fields' => $testFields, 'search' => 'test']);
+
+        $logService = $this->createMock(LogService::class);
+        $logService
+            ->expects($this->once())
+            ->method('search')
+            ->with('test')
+            ->willReturn([
+                new LogEntryView(
+                    datetime: '2025-04-28T10:00:00Z',
+                    channel: 'app',
+                    level: 'ERROR',
+                    message: 'Test message',
+                    context: [],
+                ),
+            ]);
+
+        $action = new SearchAction($logService);
+        $response = $action->__invoke($request);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $body = (string) $response->getBody();
+
+        $this->assertStringContainsString('class="field-actions"', $body);
+        $this->assertStringContainsString('i-chevron-left', $body);
+        $this->assertStringContainsString('i-chevron-right', $body);
+
+        $this->assertSame(2, substr_count($body, 'aria-label="Move column left"'));
+        $this->assertSame(2, substr_count($body, 'aria-label="Move column right"'));
+        $this->assertSame(3, substr_count($body, 'aria-label="Remove column"'));
+
+        $this->assertStringContainsString('data-field="datetime"', $body);
+        $this->assertStringContainsString('data-field="message"', $body);
+        $this->assertStringContainsString('data-field="custom"', $body);
+
+        $this->assertStringContainsString('sr-only', $body);
+        $this->assertStringContainsString('Move column left', $body);
+        $this->assertStringContainsString('Move column right', $body);
+    }
+
+    /** @throws Exception */
+    public function test_invoke_with_single_field_hides_move_buttons(): void
+    {
+        $testFields = ['datetime'];
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request
+            ->expects($this->once())
+            ->method('getQueryParams')
+            ->willReturn(['fields' => $testFields, 'search' => 'test']);
+
+        $logService = $this->createMock(LogService::class);
+        $logService
+            ->expects($this->once())
+            ->method('search')
+            ->with('test')
+            ->willReturn([
+                new LogEntryView(
+                    datetime: '2025-04-28T10:00:00Z',
+                    channel: 'app',
+                    level: 'ERROR',
+                    message: 'Test message',
+                    context: [],
+                ),
+            ]);
+
+        $action = new SearchAction($logService);
+        $response = $action->__invoke($request);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $body = (string) $response->getBody();
+
+        $this->assertSame(0, substr_count($body, 'aria-label="Move column left"'));
+        $this->assertSame(0, substr_count($body, 'aria-label="Move column right"'));
+        $this->assertSame(1, substr_count($body, 'aria-label="Remove column"'));
+        $this->assertStringContainsString('data-field="datetime"', $body);
+    }
+
+    /** @throws Exception */
     public function test_invoke_throws_exception_on_service_failure(): void
     {
         $errorMessage = 'Database connection failed';


### PR DESCRIPTION
- Add moveFieldLeft/moveFieldRight JS functions with bounds checking
- Expose functions globally via window.moveFieldLeft/Right
- Render buttons in x <- -> order with conditional visibility (move-left hidden on first field, move-right hidden on last field, both hidden when only 1 field)
- Use arrow icons (line + arrowhead) for move buttons
- Consistent 0.875rem font size for all field action buttons
- Add test for move buttons with 3 fields (checks count per type)
- Add test for single field (verifies move buttons are hidden)