### PR TITLE
ci: add Docker semantic tags and conventional commits support

### DIFF
--- a/.github/workflows/build-production-docker-image.yaml
+++ b/.github/workflows/build-production-docker-image.yaml
@@ -1,14 +1,30 @@
-name: Release silvanei/simple-log-viewer:latest image
+name: Release silvanei/simple-log-viewer image
 
 on:
   push:
     branches: [ main ]
+    tags: [ 'v*' ]
 
 jobs:
-  build:
+  build-and-push:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
     steps:
       - uses: actions/checkout@v4
+
+      - name: Docker Meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: silvanei/simple-log-viewer
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=edge,enable={{is_default_branch}}
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -22,9 +38,11 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
+          target: production
           push: true
           context: .
           platforms: linux/amd64
-          tags: silvanei/simple-log-viewer:latest
-          cache-from: type=registry,ref=silvanei/simple-log-viewer:latest
-          cache-to: type=inline
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -3,6 +3,9 @@ name: check
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
 
   code-linter:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,3 +218,84 @@ foreach ($buttons as $button) {
 - Return structured data via JSON for API endpoints
 - Use view models for HTML responses
 - Path parameters from request attributes, query params from request query params
+
+## 📝 Commit Convention (Conventional Commits)
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/) for all commits.
+
+### Format
+```
+<tipo>: <descrição>
+
+[corpo opcional]
+```
+
+### Tipos permitidos
+| Tipo | Uso | Exemplo |
+|------|-----|---------|
+| `feat` | Nova funcionalidade | `feat: add column sorting` |
+| `fix` | Correção de bug | `fix: validate datetime format` |
+| `docs` | Documentação | `docs: update API docs` |
+| `test` | Testes | `test: add LogStorage unit tests` |
+| `refactor` | Refatoração | `refactor: extract LogService class` |
+| `style` | Formatação/código estilo | `style: fix PSR-12 indentation` |
+| `chore` | Manutenção | `chore: update PHPStan config` |
+| `perf` | Performance | `perf: optimize search query` |
+| `ci` | CI/CD | `ci: add Docker semantic tags` |
+
+### Escopo (opcional)
+Use parênteses para escopo: `feat(api): add log search endpoint`
+
+### Breaking changes
+Adicione `!` após tipo/escopo: `feat!: remove deprecated endpoint`
+
+## 🏷️ Release Process
+
+### Fluxo de Release
+
+1. **Desenvolva** features em branches separadas com commits seguindo Conventional Commits
+2. **Abra PRs** e faça merge para `main` (branch protegida, merge via PR)
+3. **Prepare o release** criando uma branch `release/vX.Y.Z`:
+   - Invoque o subagente `changelog-generator` ou execute `git cliff --tag vX.Y.Z --unreleased`
+   - Atualize `CHANGELOG.md` com as mudanças geradas + detalhes manuais
+   - Atualize `"version"` no `composer.json`
+   - Crie PR da branch de release para `main`
+4. **Após o merge**, crie a tag:
+   ```bash
+   git checkout main && git pull
+   git tag v1.4.0
+   git push origin v1.4.0
+   ```
+5. **CI detecta a tag** e constrói as imagens Docker:
+   - `silvanei/simple-log-viewer:1.4.0`
+   - `silvanei/simple-log-viewer:1.4`
+   - `silvanei/simple-log-viewer:1`
+   - `silvanei/simple-log-viewer:latest`
+
+### Comandos úteis
+
+```bash
+# Gerar changelog para release
+git cliff --tag vX.Y.Z --unreleased
+
+# Build local da imagem de produção
+make build-production VERSION=1.4.0
+```
+
+### Documentação de Release
+Consulte [RELEASE.md](RELEASE.md) para o guia completo passo a passo de como criar uma release.
+
+### Changelog (git-cliff)
+
+O projeto usa [git-cliff](https://git-cliff.org) para gerar changelogs. Configuração em `cliff.toml`.
+
+- Commits que seguem Conventional Commits são agrupados por tipo (Added, Fixed, etc.)
+- Commits antigos (sem padrão) são agrupados em "Changed"
+- Sempre revise e enriqueça o changelog gerado com detalhes técnicos e exemplos
+
+## 🤝 Available Subagents
+
+### changelog-generator
+**Specialty**: Changelog generation with git-cliff
+**When to Use**: Preparing a release, generating changelog entries
+**Invocation**: `task(subagent_type="changelog-generator", ...)`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,9 +18,81 @@ Existem várias maneiras de contribuir:
 4.  **Desenvolva:** Faça as alterações necessárias no código.
 5.  **Teste:** Certifique-se de que todos os testes existentes passam (`make test`). Se estiver adicionando uma nova funcionalidade ou corrigindo um bug, adicione novos testes que cubram suas alterações.
 6.  **Verifique a Qualidade do Código:** Rode as ferramentas de qualidade: `make phpcs` e `make phpstan`. Corrija quaisquer problemas apontados.
-7.  **Commit:** Faça commits claros e concisos: `git commit -m 'Feat: Adiciona funcionalidade X'` ou `git commit -m 'Fix: Corrige problema Y na classe Z'`.
+7.  **Commit:** Faça commits seguindo [Conventional Commits](https://www.conventionalcommits.org/):
+    ```
+    <tipo>: <descrição>
+    ```
+    Tipos: `feat`, `fix`, `docs`, `test`, `refactor`, `style`, `chore`, `perf`, `ci`.
+    Exemplos:
+    ```bash
+    git commit -m "feat: add column reordering"
+    git commit -m "fix: correct datetime validation"
+    git commit -m "test: add boundary tests for search limit"
+    git commit -m "docs: update API documentation"
+    ```
 8.  **Push:** Envie suas alterações para o seu fork: `git push origin minha-nova-feature`.
 9.  **Abra um Pull Request (PR):** Vá até o repositório original (`silvanei/simple-log-viewer`) e abra um Pull Request da sua branch para a branch `main` do repositório original. Descreva suas alterações no PR.
+
+> 📖 Consulte o guia completo em [RELEASE.md](RELEASE.md) para instruções detalhadas.
+
+## 🏷️ Fluxo de Release
+
+### Como criar um release
+
+1. **Prepare a branch de release:**
+   ```bash
+   git checkout main && git pull
+   git checkout -b release/v1.4.0
+   ```
+
+2. **Gere o changelog automaticamente:**
+   ```bash
+   # Via Makefile
+   make changelog VERSION=1.4.0
+   
+   # Ou diretamente com git-cliff
+   git cliff --tag v1.4.0 --unreleased
+   ```
+
+3. **Atualize o `CHANGELOG.md`:**
+   - Integre o changelog gerado
+   - Enriqueça com detalhes técnicos e exemplos (se necessário)
+   - Mantenha o cabeçalho `[Unreleased]` para mudanças futuras
+
+4. **Atualize a versão no `composer.json`:**
+   ```bash
+   # Altere "version": "1.3.0" para "version": "1.4.0"
+   ```
+
+5. **Commite e crie PR:**
+   ```bash
+   git add CHANGELOG.md composer.json
+   git commit -m "chore: release v1.4.0"
+   git push origin release/v1.4.0
+   ```
+   Abra um PR de `release/v1.4.0` para `main`.
+
+6. **Após o merge, crie a tag:**
+   ```bash
+   git checkout main && git pull
+   git tag v1.4.0
+   git push origin v1.4.0
+   ```
+
+7. **CI constrói automaticamente** as imagens Docker:
+   - `silvanei/simple-log-viewer:1.4.0`
+   - `silvanei/simple-log-viewer:1.4`
+   - `silvanei/simple-log-viewer:1`
+   - `silvanei/simple-log-viewer:latest`
+
+### Changelog (git-cliff)
+
+O projeto usa [git-cliff](https://git-cliff.org/) para gerar changelogs a partir do histórico de commits.
+
+- **Configuração**: `cliff.toml` (raiz do projeto)
+- **Commits seguindo Conventional Commits** são agrupados por tipo (Added, Fixed, etc.)
+- **Commits antigos** (sem padrão definido) são agrupados em "Changed"
+- **Sempre revise** o changelog gerado e adicione detalhes técnicos quando necessário
 
 ## Padrões de Código
 

--- a/Makefile
+++ b/Makefile
@@ -49,3 +49,16 @@ infection:
 
 check:
 	$(DOCKER_CONTAINER_RUN) composer check
+
+build-production:
+	docker build --target production \
+		-t silvanei/simple-log-viewer:$(VERSION) \
+		-t silvanei/simple-log-viewer:latest .
+
+changelog:
+	@echo "Generating changelog for v$(VERSION)..."
+	@command -v git-cliff >/dev/null 2>&1 && \
+		git cliff --tag v$(VERSION) --unreleased || \
+		docker run --rm -v $(PWD):/workspace -w /workspace \
+			orhun/git-cliff:latest \
+			git cliff --tag v$(VERSION) --unreleased

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,181 @@
+# Release Process
+
+Este documento descreve o processo completo para criar uma nova release do Simple Log Viewer.
+
+## 📋 Pré-requisitos
+
+- Acesso de escrita ao repositório (`silvanei/simple-log-viewer`)
+- Docker instalado para build local (opcional)
+- Para gerar changelog: **git-cliff** (opcional — o Makefile resolve automaticamente)
+
+### 🔧 Instalação do git-cliff
+
+O `git-cliff` é uma ferramenta separada (não é um comando padrão do git). Escolha uma opção:
+
+**Opção A — Via Makefile (recomendado, não precisa instalar nada):**
+```bash
+make changelog VERSION=1.4.0
+```
+O Makefile detecta automaticamente se o git-cliff está instalado localmente. Se não estiver, ele executa via Docker usando a imagem oficial `orhun/git-cliff:latest`.
+
+**Opção B — Instalar localmente (Linux/macOS):**
+```bash
+# Com cargo (Rust)
+cargo install git-cliff
+
+# Ou via gerenciador de pacotes
+# macOS: brew install git-cliff
+# Arch: pacman -S git-cliff
+```
+
+**Opção C — Direto via Docker (sem Makefile):**
+```bash
+docker run --rm -v $(pwd):/workspace -w /workspace orhun/git-cliff:latest \
+  git cliff --tag v1.4.0 --unreleased
+```
+
+## 🏷️ Convenção de Commits
+
+O projeto utiliza [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>: <description>
+```
+
+| Tipo | Uso |
+|------|-----|
+| `feat` | Nova funcionalidade |
+| `fix` | Correção de bug |
+| `docs` | Documentação |
+| `test` | Testes |
+| `refactor` | Refatoração |
+| `style` | Formatação/código estilo |
+| `chore` | Manutenção |
+| `perf` | Performance |
+| `ci` | CI/CD |
+
+## 🔄 Passo a Passo para Criar uma Release
+
+### 1. Prepare a branch de release
+
+```bash
+# Certifique-se de estar na main atualizada
+git checkout main
+git pull
+
+# Crie uma branch de release
+git checkout -b release/v1.4.0
+```
+
+### 2. Gere o changelog
+
+**Opção A — Usando o subagente opencode (recomendado):**
+```bash
+# Invoque o subagente changelog-generator
+# Ele executará git-cliff e atualizará o CHANGELOG.md
+```
+
+**Opção B — Usando Makefile:**
+```bash
+make changelog VERSION=1.4.0
+```
+
+**Opção C — Direto com git-cliff:**
+```bash
+git cliff --tag v1.4.0 --unreleased
+```
+
+### 3. Revise e enriqueça o CHANGELOG.md
+
+O git-cliff gera uma **base** com os commits agrupados por tipo. Revise e enriqueça:
+
+- Adicione **"Technical Details"** para mudanças complexas
+- Adicione **"Usage Examples"** code snippets para novas features
+- Adicione **"Dependencies Updated"** se houver mudanças no `composer.json`
+- Destaque **Breaking Changes** se houver
+- Mantenha o cabeçalho `[Unreleased]` para mudanças futuras
+
+### 4. Atualize a versão no composer.json
+
+```bash
+# Altere manualmente ou use o subagente
+# "version": "1.3.0" → "version": "1.4.0"
+```
+
+### 5. Commite e crie PR
+
+```bash
+git add CHANGELOG.md composer.json
+git commit -m "chore: release v1.4.0"
+git push origin release/v1.4.0
+```
+
+Abra um Pull Request no GitHub de `release/v1.4.0` para `main`.
+
+### 6. Após o merge do PR, crie a tag
+
+```bash
+git checkout main
+git pull
+git tag v1.4.0
+git push origin v1.4.0
+```
+
+### 7. CI constrói as imagens automaticamente
+
+O GitHub Actions detecta o push da tag `v1.4.0` e gera:
+
+| Tag Docker | Descrição |
+|------------|-----------|
+| `silvanei/simple-log-viewer:1.4.0` | Versão exata |
+| `silvanei/simple-log-viewer:1.4` | Major.Minor |
+| `silvanei/simple-log-viewer:1` | Major |
+| `silvanei/simple-log-viewer:latest` | Última versão estável |
+
+## 🐳 Build Local (Opcional)
+
+Para testar a imagem de produção localmente antes do release:
+
+```bash
+make build-production VERSION=1.4.0
+```
+
+Isso constrói:
+- `silvanei/simple-log-viewer:1.4.0`
+- `silvanei/simple-log-viewer:latest`
+
+## 📊 Exemplo Completo
+
+```bash
+# Preparação
+git checkout main && git pull
+git checkout -b release/v1.4.0
+
+# Gera changelog
+git cliff --tag v1.4.0 --unreleased
+
+# Edita CHANGELOG.md (adiciona detalhes técnicos)
+# Edita composer.json (bumpa versão)
+
+# Commit e PR
+git add CHANGELOG.md composer.json
+git commit -m "chore: release v1.4.0"
+git push origin release/v1.4.0
+# → Abre PR no GitHub, revisa e mergeia
+
+# Tag
+git checkout main && git pull
+git tag v1.4.0 && git push origin v1.4.0
+# → CI constrói as imagens automaticamente 🎉
+```
+
+## ❓ Troubleshooting
+
+### A tag foi criada mas o CI não disparou
+Verifique se a tag segue o padrão `v*.*.*` (ex: `v1.4.0`, não `1.4.0` ou `v1.4`).
+
+### O changelog está vazio
+Verifique se os commits da branch seguem Conventional Commits. Commits sem padrão caem no grupo "Changed".
+
+### Docker build falhou localmente
+Certifique-se de que o Docker está rodando e você tem permissão para executar `docker build`.

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,37 @@
+[changelog]
+header = """
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+"""
+body = """
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first }}
+{% for commit in commits %}
+- {{ commit.message | upper_first }}{% if commit.breaking %} (BREAKING){% endif %}
+{% endfor %}
+{% endfor %}
+"""
+trim = true
+postprocessors = [{ pattern = "Other", replace = "Changed" }]
+
+[git]
+conventional_commits = true
+filter_unconventional = false
+commit_parsers = [
+    { message = "^feat", group = "Added" },
+    { message = "^fix", group = "Fixed" },
+    { message = "^docs", group = "Documentation" },
+    { message = "^test", group = "Test" },
+    { message = "^refactor", group = "Changed" },
+    { message = "^style", group = "Style" },
+    { message = "^chore", group = "Maintenance" },
+    { message = "^perf", group = "Performance" },
+    { message = "^ci", group = "CI/CD" },
+    { message = ".*", group = "Other" },
+]

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "s3/simple-log-viewer",
-  "version": "0.0.1",
+  "version": "1.3.0",
   "description": "Simple log viewer for development environment",
   "authors": [
     {

--- a/test/Support/MakefileTargetTest.php
+++ b/test/Support/MakefileTargetTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Support\S3\Log\Viewer;
+
+use PHPUnit\Framework\Attributes\Before;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test that the Makefile contains the expected build and changelog targets.
+ */
+final class MakefileTargetTest extends TestCase
+{
+    private string $makefileContent = '';
+
+    #[Before]
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $makefilePath = __DIR__ . '/../../Makefile';
+        $content = file_get_contents($makefilePath);
+
+        if ($content === false) {
+            throw new \RuntimeException('Could not read Makefile');
+        }
+
+        $this->makefileContent = $content;
+    }
+
+    public function testMakefile_ShouldContainBuildProductionTarget(): void
+    {
+        $this->assertStringContainsString('build-production:', $this->makefileContent);
+    }
+
+    public function testBuildProduction_ShouldUseDockerBuildTarget(): void
+    {
+        $this->assertStringContainsString('--target production', $this->makefileContent);
+    }
+
+    public function testBuildProduction_ShouldTagWithVersion(): void
+    {
+        $this->assertStringContainsString('$(VERSION)', $this->makefileContent);
+    }
+
+    public function testBuildProduction_ShouldTagWithLatest(): void
+    {
+        $this->assertStringContainsString('latest', $this->makefileContent);
+    }
+
+    public function testMakefile_ShouldContainChangelogTarget(): void
+    {
+        $this->assertStringContainsString('changelog:', $this->makefileContent);
+    }
+
+    public function testChangelog_ShouldUseGitCliff(): void
+    {
+        $this->assertStringContainsString('git cliff', $this->makefileContent);
+    }
+
+    public function testChangelog_ShouldPassVersionArgument(): void
+    {
+        $this->assertStringContainsString('$(VERSION)', $this->makefileContent);
+    }
+}

--- a/test/Support/ReleaseTagTest.php
+++ b/test/Support/ReleaseTagTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Support\S3\Log\Viewer;
+
+use Generator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test that semantic version tags are correctly parsed into Docker-style tags.
+ *
+ * This mirrors the logic used by docker/metadata-action in CI:
+ * - Git tag v1.4.0 → Docker tags: 1.4.0, 1.4, 1
+ */
+final class ReleaseTagTest extends TestCase
+{
+    /**
+     * @param array<int, string> $expectedTags
+     */
+    #[DataProvider('semverTagProvider')]
+    public function testSemverTag_ShouldGenerateVersionTag(string $gitTag, array $expectedTags): void
+    {
+        $version = ltrim($gitTag, 'v');
+        $parts = explode('.', $version);
+
+        $tags = [
+            $version,
+            $parts[0] . '.' . $parts[1],
+            $parts[0],
+        ];
+
+        $this->assertSame($expectedTags, $tags);
+    }
+
+    /**
+     * @return Generator<string, array{string, array<int, string>}>
+     */
+    public static function semverTagProvider(): Generator
+    {
+        yield 'stable release' => ['v1.4.0', ['1.4.0', '1.4', '1']];
+        yield 'major release' => ['v2.0.0', ['2.0.0', '2.0', '2']];
+        yield 'patch release' => ['v1.4.1', ['1.4.1', '1.4', '1']];
+        yield 'initial release' => ['v0.1.0', ['0.1.0', '0.1', '0']];
+        yield 'minor bump' => ['v1.5.0', ['1.5.0', '1.5', '1']];
+        yield 'major bump' => ['v3.0.0', ['3.0.0', '3.0', '3']];
+        yield 'double digit' => ['v10.0.0', ['10.0.0', '10.0', '10']];
+        yield 'patch bump' => ['v2.1.5', ['2.1.5', '2.1', '2']];
+    }
+
+    public function testGitTag_ShouldStripVPrefix(): void
+    {
+        $this->assertSame('1.4.0', ltrim('v1.4.0', 'v'));
+        $this->assertSame('2.0.0', ltrim('v2.0.0', 'v'));
+        $this->assertSame('0.1.0', ltrim('v0.1.0', 'v'));
+    }
+
+    /**
+     * @param array<int, string> $tags
+     */
+    #[DataProvider('semverTagProvider')]
+    public function testDockerTags_ShouldFollowOrder(string $gitTag, array $tags): void
+    {
+        // Most specific tag first (version), then major.minor, then major
+        $this->assertSame(ltrim($gitTag, 'v'), $tags[0], 'First tag should be full version');
+        $this->assertMatchesRegularExpression('/^\d+\.\d+$/', $tags[1], 'Second tag should be major.minor');
+        $this->assertMatchesRegularExpression('/^\d+$/', $tags[2], 'Third tag should be major only');
+    }
+
+    #[DataProvider('tagFilterProvider')]
+    public function testGitTag_ShouldMatchCiTriggerPattern(string $gitTag, bool $shouldTriggerCI): void
+    {
+        // The CI is configured to trigger on 'v*' pattern
+        $matches = preg_match('/^v\d+\.\d+\.\d+$/', $gitTag) === 1;
+
+        $this->assertSame($shouldTriggerCI, $matches, "Tag '$gitTag' should trigger CI: $shouldTriggerCI");
+    }
+
+    /**
+     * @return Generator<string, array{string, bool}>
+     */
+    public static function tagFilterProvider(): Generator
+    {
+        yield 'valid semver' => ['v1.4.0', true];
+        yield 'valid major' => ['v2.0.0', true];
+        yield 'missing v prefix' => ['1.4.0', false];
+        yield 'missing patch' => ['v1.4', false];
+        yield 'rc tag' => ['v1.4.0-rc1', false];
+        yield 'beta tag' => ['v2.0.0-beta.1', false];
+        yield 'no tag' => ['main', false];
+        yield 'random string' => ['vabc', false];
+    }
+}


### PR DESCRIPTION
- Add git-cliff configuration (cliff.toml) for automated changelog generation
- Create RELEASE.md with complete step-by-step release guide
- Update CI workflow to generate semantic Docker tags using docker/metadata-action (v1.4.0, v1.4, v1, latest, edge)
- Add build-production and changelog targets to Makefile
- Update composer.json version to 1.3.0
- Add Conventional Commits documentation to AGENTS.md and CONTRIBUTING.md
- Add minimum permissions (contents: read) to main CI workflow
- Add tests for semantic tag parsing and Makefile targets