### PR TITLE
chore: release v1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.1] - 2026-07-20
+
+### Changed
+- Update Docker image dependencies
+  - FrankenPHP 1.11.2 → 1.12.3
+  - Composer 2.9.2 → 2.10.2 (includes security fixes)
+
+### Security
+- Add multi-stage production build to remove composer binary from final image
+- Move `COMPOSER_ALLOW_SUPERUSER=1` to only RUN instructions (not global ENV)
+- Update `.dockerignore` with additional security patterns (`.git`, `.env*`, `*.pem`, `*.key`, `*.cert`, `*.log`, `.github`, `*.md`)
+
 ## [1.4.0] - 2026-07-15
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "s3/simple-log-viewer",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Simple log viewer for development environment",
   "authors": [
     {


### PR DESCRIPTION
## What
Prepare release v1.4.1 with Docker security improvements.

## Why
Security fixes in Composer 2.10.2 and multi-stage build to reduce attack surface.

## Changes
- Update FrankenPHP 1.11.2 → 1.12.3
- Update Composer 2.9.2 → 2.10.2
- Add multi-stage production build (builder → production)
- Remove composer binary from production image
- Move COMPOSER_ALLOW_SUPERUSER=1 to only RUN instructions
- Update .dockerignore with security patterns

## Impact
- Smaller production image size
- Reduced attack surface (no composer in production)
- No application behavior changes